### PR TITLE
[feat] 카카오 로그인 및 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    // Webflux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    //mac netty 설정
+    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/example/pongguel/config/ApiConfig.java
+++ b/src/main/java/org/example/pongguel/config/ApiConfig.java
@@ -1,0 +1,29 @@
+package org.example.pongguel.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+@Configuration
+public class ApiConfig {
+
+    /*
+    * WebClient의 UriComponentsBuilder.encode() 방식의 인코딩 방지
+    * key 값이 달라지는 것을 방지하기 위해 DefaultUriBuilderFactory 생성
+    * encoding 모드 지정
+    * */
+    @Bean
+    public DefaultUriBuilderFactory builderFactory() {
+        DefaultUriBuilderFactory builderFactory = new DefaultUriBuilderFactory();
+        builderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
+        return builderFactory;
+    }
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder()
+                .uriBuilderFactory(builderFactory())
+                .build();
+    }
+}

--- a/src/main/java/org/example/pongguel/exception/ErrorCode.java
+++ b/src/main/java/org/example/pongguel/exception/ErrorCode.java
@@ -16,7 +16,27 @@ public enum ErrorCode {
     // 요청 본문 형식 오류 추가
     INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "요청 본문의 형식이 올바르지 않습니다."),
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 엔티티입니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서비스 이용에 장애가 있습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서비스 이용에 장애가 있습니다."),
+
+    // 카카오 회원가입 및 로그인
+    //400
+    KAKAO_ACCESS_TOKEN_BAD_REQUEST(HttpStatus.BAD_REQUEST,"잘못된 카카오 access_token 파라미터 요청입니다."),
+    KAKAO_USER_INFO_BAD_REQUEST(HttpStatus.BAD_REQUEST,"잘못된 카카오 사용자정보 파라미터 요청입니다."),
+    //401
+    KAKAO_ACCESS_TOKEN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"인가코드 인증에 실패했습니다."),
+    KAKAO_USER_INFO_UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"카카오 액세스 토큰이 만료되었거나 유효하지 않습니다."),
+    //403
+    KAKAO_ACCESS_TOKEN_FORBIDDEN(HttpStatus.FORBIDDEN,"카카오 로그인이 비활성화됐습니다"),
+    KAKAO_USER_INFO_FORBIDDEN(HttpStatus.FORBIDDEN,"카카오 정보 요청 권한이 없습니다."),
+    //404
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    //409
+    PROCESS_USER_CONFLICT(HttpStatus.CONFLICT,"이미 가입한 회원입니다."),
+    //500
+    KAKAO_ACCESS_TOKEN_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"OAuth 서버 일시적 오류가 생겼습니다."),
+    KAKAO_USER_INFO_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"카카오서버 내부의 일시적 오류가 생겼습니다."),
+    PROCESS_USER_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"데이터베이스 오류가 생겼습니다.");
+
 
     //공통
     private final HttpStatus status;

--- a/src/main/java/org/example/pongguel/exception/UnauthorizedException.java
+++ b/src/main/java/org/example/pongguel/exception/UnauthorizedException.java
@@ -1,0 +1,12 @@
+package org.example.pongguel.exception;
+
+public class UnauthorizedException extends BaseException {
+
+    public UnauthorizedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public UnauthorizedException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/org/example/pongguel/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/pongguel/exception/handler/GlobalExceptionHandler.java
@@ -37,4 +37,10 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(new ErrorResponse(e.getErrorCode(), e.getErrorCode().getMessage()));
     }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthorizedException(UnauthorizedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new ErrorResponse(e.getErrorCode(), e.getErrorCode().getMessage()));
+    }
 }

--- a/src/main/java/org/example/pongguel/user/controller/KakaoController.java
+++ b/src/main/java/org/example/pongguel/user/controller/KakaoController.java
@@ -1,0 +1,44 @@
+package org.example.pongguel.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.example.pongguel.user.dto.KakaoUserInfo;
+import org.example.pongguel.user.dto.LoginResponse;
+import org.example.pongguel.user.dto.LoginResult;
+import org.example.pongguel.user.dto.UserInfoResponse;
+import org.example.pongguel.user.service.KakaoService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/kakao")
+@Tag(name="Kakao",description = "카카오 로그인에 관련된 Api입니다.")
+public class KakaoController {
+    private final KakaoService kakaoService;
+
+    // 카카오 로그인 페이지로 리다이렉트
+    @GetMapping("/login")
+    @Operation(summary = "카카오 인가코드 발급", description = "카카오 인가코드 페이지로 리다이렉트됩니다.")
+    public ResponseEntity<Void> redirectToKakaoAuth() {
+        String kakaoAuthUtl = kakaoService.getKakaoAuthUrl();
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .location(URI.create(kakaoAuthUtl))
+                .build();
+    }
+    // 카카오 로그인
+    @GetMapping("/callback")
+    @Operation(summary = "카카오 로그인",
+            description = "1. 인가코드를 바탕으로 accessToken을 발급받기" +
+                          "2.사용자 정보를 kakao로 받아오기" +
+                          "3.사용자 정보가 없을 시 회원가입 동시진행")
+    public ResponseEntity<LoginResponse> kakaoLoginCallback(@RequestParam("code") String code) {
+        LoginResult result = kakaoService.processKakaoLongin(code);
+        return ResponseEntity.status(result.status()).body(result.loginResponse());
+    }
+}

--- a/src/main/java/org/example/pongguel/user/domain/Grade.java
+++ b/src/main/java/org/example/pongguel/user/domain/Grade.java
@@ -1,0 +1,10 @@
+package org.example.pongguel.user.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Grade {
+    NORMAL, PREMIUM, ADMIN;
+}

--- a/src/main/java/org/example/pongguel/user/domain/User.java
+++ b/src/main/java/org/example/pongguel/user/domain/User.java
@@ -1,0 +1,32 @@
+package org.example.pongguel.user.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "user_id", nullable = false)
+    private UUID id;
+
+    @Column(unique = true, nullable = false)
+    private String accountEmail;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column
+    private String profileImage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Grade grade;
+}

--- a/src/main/java/org/example/pongguel/user/dto/KakaoUserInfo.java
+++ b/src/main/java/org/example/pongguel/user/dto/KakaoUserInfo.java
@@ -1,0 +1,8 @@
+package org.example.pongguel.user.dto;
+
+
+public record KakaoUserInfo(Long id,
+                            String email,
+                            String nickname,
+                            String thumbnail_image_url) {
+}

--- a/src/main/java/org/example/pongguel/user/dto/LoginResponse.java
+++ b/src/main/java/org/example/pongguel/user/dto/LoginResponse.java
@@ -1,0 +1,5 @@
+package org.example.pongguel.user.dto;
+
+public record LoginResponse(String message,
+                            UserInfoResponse userInfoResponse) {
+}

--- a/src/main/java/org/example/pongguel/user/dto/LoginResult.java
+++ b/src/main/java/org/example/pongguel/user/dto/LoginResult.java
@@ -1,0 +1,6 @@
+package org.example.pongguel.user.dto;
+
+import org.springframework.http.HttpStatus;
+
+public record LoginResult(HttpStatus status, LoginResponse loginResponse) {
+}

--- a/src/main/java/org/example/pongguel/user/dto/UserInfoResponse.java
+++ b/src/main/java/org/example/pongguel/user/dto/UserInfoResponse.java
@@ -1,0 +1,10 @@
+package org.example.pongguel.user.dto;
+
+import org.example.pongguel.user.domain.Grade;
+
+public record UserInfoResponse(String accountEmail,
+                               String nickname,
+                               String profile_image_url,
+                               Grade grade,
+                               boolean isNewUser) {
+}

--- a/src/main/java/org/example/pongguel/user/repository/UserRepository.java
+++ b/src/main/java/org/example/pongguel/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package org.example.pongguel.user.repository;
+
+import org.example.pongguel.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+    // 이메일로 사용자 찾기
+    Optional<User> findByAccountEmail(String accountEmail);
+    // 신규회원 유무 확인
+    boolean existsByAccountEmail(String accountEmail);
+}

--- a/src/main/java/org/example/pongguel/user/service/KakaoService.java
+++ b/src/main/java/org/example/pongguel/user/service/KakaoService.java
@@ -1,0 +1,142 @@
+package org.example.pongguel.user.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
+import lombok.extern.slf4j.Slf4j;
+import org.example.pongguel.exception.*;
+import org.example.pongguel.user.domain.Grade;
+import org.example.pongguel.user.domain.User;
+import org.example.pongguel.user.dto.*;
+import org.example.pongguel.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.example.pongguel.exception.ErrorCode.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class KakaoService {
+
+    @Value("${kakao.client_id}")
+    private String clientId;
+    @Value("${kakao.redirect_uri}")
+    private String redirectUri;
+    @Value("${kakao.oauth_uri}")
+    private String oauthUri;
+    @Value("${kakao.oauth_token_uri}")
+    private String oauthTokenUri;
+    @Value("${kakao.oauth_user_uri}")
+    private String oauthUserUri;
+
+    private final WebClient webClient;
+    private final UserRepository userRepository;
+
+    // 카카오 인증코드 발급 URL 생성
+    public String getKakaoAuthUrl(){
+        return String.format("%s?response_type=code&client_id=%s&redirect_uri=%s",
+                oauthUri, clientId, redirectUri);
+    }
+
+    // 카카오 로그인 및 회원가입 진행
+    public LoginResult processKakaoLongin(String code){
+        String accessToken = getAccessToken(code);
+        KakaoUserInfo kakaoUserInfo = getKakaoUserInfo(accessToken);
+        UserInfoResponse userInfoResponse = processKakaoUser(kakaoUserInfo);
+
+        HttpStatus status = userInfoResponse.isNewUser() ? HttpStatus.CREATED : HttpStatus.OK;
+        String message = userInfoResponse.isNewUser() ? "회원가입 및 카카오 로그인에 성공했습니다!" : "카카오 로그인에 성공했습니다.";
+        return new LoginResult(status,new LoginResponse(message,userInfoResponse));
+    }
+
+    // 카카오 accessToken 발급
+    private String getAccessToken(String code){
+        MultiValueMap<String,String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code"); // 인증방식 'authorization_code로 지정
+        body.add("client_id", clientId); // 클라이언트 ID 추가
+        body.add("redirect_uri", redirectUri); // 리다이렉트 ID 추가
+        body.add("code", code); // 인증 코드 추가
+
+        // WebClient를 사용하여 POST 요청
+        try {
+            return webClient.post()
+                    // 토큰 요청 URI
+                    .uri(oauthTokenUri)
+                    // 컨텐츠 타입 설정
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    // 요청 본문에 form 데이터 추가
+                    .body(BodyInserters.fromFormData(body))
+                    // 응답 받기
+                    .retrieve()
+                    // 응답 본문을 JsonNode로 변환
+                    .bodyToMono(JsonNode.class)
+                    // JsonNode에서 access_token 추출
+                    .map(jsonNode -> jsonNode.path("access_token").asText())
+                    .block();
+        } catch (WebClientResponseException e){
+            log.error("카카오 accessToken 발급 실패. 상태 코드: {}, 응답: {}", e.getRawStatusCode(), e.getResponseBodyAsString());
+            throw new BadRequestException(ErrorCode.KAKAO_ACCESS_TOKEN_BAD_REQUEST);
+        } catch (Exception e) {
+            log.error("카카오 accessToken 발급 중 예상치 못한 오류 발생", e);
+            throw new InternalServerException(ErrorCode.KAKAO_ACCESS_TOKEN_INTERNAL_SERVER_ERROR);
+        }
+    }
+    // 카카오 사용자 정보 가져오기
+    private KakaoUserInfo getKakaoUserInfo(String accessToken){
+       try {
+           return webClient.post()
+                   .uri(oauthUserUri)
+                   .header("Authorization", "Bearer " + accessToken)
+                   .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                   .retrieve()
+                   .bodyToMono(JsonNode.class)
+                   .map(jsonNode -> {
+                       Long id = jsonNode.path("id").asLong();
+                       String email = jsonNode.path("kakao_account").path("email").asText();
+                       String nickname = jsonNode.path("kakao_account").path("profile").path("nickname").asText();
+                       String thumbnail_image_url = jsonNode.path("kakao_account").path("profile").path("thumbnail_image_url").asText();
+                   return new KakaoUserInfo(id,email,nickname,thumbnail_image_url);
+                   })
+                   .block();
+       } catch (WebClientResponseException e){
+           log.error("카카오 사용자 정보 조회에 실패했습니다. 상태코드: {}, 응답:{}", e.getRawStatusCode(), e.getResponseBodyAsString());
+           throw new InternalServerException(ErrorCode.KAKAO_USER_INFO_INTERNAL_SERVER_ERROR);
+       }
+    }
+
+    // 카카오 로그인 진행
+    private UserInfoResponse processKakaoUser(KakaoUserInfo kakaoUserInfo){
+        // 신규회원 유무 확인
+       boolean isNewUser = !userRepository.existsByAccountEmail(kakaoUserInfo.email());
+        User user = userRepository.findByAccountEmail(kakaoUserInfo.email())
+               .orElseGet(()->{
+                   // 회원정보가 없다면 회원가입 진행
+                   User newUser = User.builder()
+                           .accountEmail(kakaoUserInfo.email())
+                           .nickname(kakaoUserInfo.nickname())
+                           .profileImage(kakaoUserInfo.thumbnail_image_url())
+                           .grade(Grade.NORMAL)
+                           .build();
+                   return userRepository.save(newUser);
+               });
+       return new UserInfoResponse(user.getAccountEmail(), user.getNickname(),
+               user.getProfileImage(),user.getGrade(),isNewUser);
+    }
+}


### PR DESCRIPTION
## Issue
- #5 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
ex) feat/user_create -> dev

## 변경 사항
- 사용자는 카카오 계정, 비밀번호로 로그인합니다.
- 사용자는 카카오 계정, 닉네임, 프로필 사진 제공에 필수로 동의해야 합니다.
- `webflux`, `macOS netty `의존성 추가
- `ApiConfig`의 `encoding` 설정 추가

## 테스트 결과

<details>
  <summary><strong> 카카오 인가코드 발급 </strong></summary>
  <div markdown="1">
  
### Request

```java
HTTP : GET
URL: /api/kakao/login
```
### Response : 성공시

`200 OK`

```
카카오 인가코드 발급 페이지로 리다이렉트됩니다.
```
  </details>

<details>
  <summary><strong> 카카오 로그인 및 회원가입 </strong></summary>
  <div markdown="1">
  
### Request

```java
HTTP : GET
URL: /api/kakao/callback
```
- Request Param

```
code: 카카오톡 로그인 인가코드
```

### Response : 성공시

`200 OK`
- 회원정보가 있는 경우

```
{
  "message": "카카오 로그인에 성공했습니다.",
  "userInfoResponse": {
    "accountEmail": "이메일",
    "nickname": "닉네임",
    "profile_image_url": "프로필_url",
    "grade": "NORMAL",
    "isNewUser": false // 이미 회원인 경우
  }
}
```

`201 Created`
- 회원정보가 없는 경우

```
{
  "message": "회원가입 및 카카오 로그인에 성공했습니다!",
  "userInfoResponse": {
    "accountEmail": "이메일",
    "nickname": "닉네임",
    "profile_image_url": "프로필_url",
    "grade": "NORMAL",
    "isNewUser": true 
  }
}
```

### Reponse : 실패시

<details>
<summary><strong> 400 Bad Request </strong></summary>
<div markdown="1">

```
{
  "status": 400,
  "message": "잘못된 카카오 access_token 파라미터 요청입니다."
}
  ```

</details>


<details>
<summary><strong> 500 Internal Server Error </strong></summary>
<div markdown="1">
  

```
{
  "status": 500,
  "message": "OAuth 서버 일시적 오류가 생겼습니다." 
}
 ```

```
{
  "status": 500,
  "message": "카카오서버 내부의 일시적 오류가 생겼습니다." 
}
 ```

</details>

  </details>