### PR TITLE
[feat] 카카오 로그아웃 및 서비스 로그아웃 기능 구현

### DIFF
--- a/src/main/java/org/example/pongguel/config/SecurityConfig.java
+++ b/src/main/java/org/example/pongguel/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeRequests(authz -> authz
-                        .requestMatchers("/api/kakao/**","/api/auth/**","/redis/**").permitAll() // 카카오 로그인
+                        .requestMatchers("/api/kakao/**","/api/auth/**","/redis/**","/api/main/**").permitAll() // 카카오 로그인
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll() //swagger
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/org/example/pongguel/main/controller/MainController.java
+++ b/src/main/java/org/example/pongguel/main/controller/MainController.java
@@ -1,0 +1,21 @@
+package org.example.pongguel.main.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/main")
+@RestController
+@RequiredArgsConstructor
+@Tag(name="Main",description = "퐁글서비스의 메인 페이지 Api입니다.")
+public class MainController {
+
+    @GetMapping("/ponggeul")
+    public ResponseEntity<String> ponggeul() {
+        String welcomeMessage = "퐁글퐁글 서비스를 시작합니다!";
+        return ResponseEntity.ok(welcomeMessage);
+    }
+}

--- a/src/main/java/org/example/pongguel/user/controller/KakaoController.java
+++ b/src/main/java/org/example/pongguel/user/controller/KakaoController.java
@@ -18,7 +18,7 @@ import java.net.URI;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/kakao")
-@Tag(name="Kakao",description = "카카오 로그인에 관련된 Api입니다.")
+@Tag(name="Kakao",description = "카카오 로그인/로그아웃에 관련된 Api입니다.")
 public class KakaoController {
     private final KakaoService kakaoService;
 
@@ -31,6 +31,7 @@ public class KakaoController {
                 .location(URI.create(kakaoAuthUtl))
                 .build();
     }
+
     // 카카오 로그인
     @GetMapping("/callback")
     @Operation(summary = "카카오 로그인",
@@ -40,5 +41,15 @@ public class KakaoController {
     public ResponseEntity<LoginResponse> kakaoLoginCallback(@RequestParam("code") String code) {
         LoginResult result = kakaoService.processKakaoLongin(code);
         return ResponseEntity.status(result.status()).body(result.loginResponse());
+    }
+
+    // 카카오 로그아웃 페이지로 리다이렉트
+    @GetMapping("/logout")
+    @Operation(summary = "카카오계정과 함께 로그아웃", description = "카카오 로그아웃 페이지로 리다이렉트됩니다.")
+    public ResponseEntity<Void> getKakaoAuthLogoutUrl() {
+        String kakaoAuthUtl = kakaoService.getKakaoAuthLogoutUrl();
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .location(URI.create(kakaoAuthUtl))
+                .build();
     }
 }

--- a/src/main/java/org/example/pongguel/user/domain/User.java
+++ b/src/main/java/org/example/pongguel/user/domain/User.java
@@ -17,6 +17,9 @@ public class User {
     @Column(name = "user_id", nullable = false)
     private UUID id;
 
+    @Column(nullable = false)
+    private Long kakaoId;
+
     @Column(unique = true, nullable = false)
     private String accountEmail;
 

--- a/src/main/java/org/example/pongguel/user/service/KakaoService.java
+++ b/src/main/java/org/example/pongguel/user/service/KakaoService.java
@@ -30,12 +30,16 @@ public class KakaoService {
     private String clientId;
     @Value("${kakao.redirect_uri}")
     private String redirectUri;
+    @Value("${kakao.logout_redirect_uri}")
+    private String logoutRedirectUri;
     @Value("${kakao.oauth_uri}")
     private String oauthUri;
     @Value("${kakao.oauth_token_uri}")
     private String oauthTokenUri;
     @Value("${kakao.oauth_user_uri}")
     private String oauthUserUri;
+    @Value("${kakao.oauth_logout_uri}")
+    private String oauthLogoutUri;
 
     private final WebClient webClient;
     private final UserRepository userRepository;
@@ -61,6 +65,12 @@ public class KakaoService {
         JwtTokenDto jwtTokenDto = new JwtTokenDto(jwtAccessToken, jwtRefreshToken);
         // LoginResult 객체 생성 및 반환
         return new LoginResult(status,new LoginResponse(message,userInfoResponse,jwtTokenDto));
+    }
+
+    // 카카오 로그아웃 URL 생성
+    public String getKakaoAuthLogoutUrl(){
+        return String.format("%s?response_type=code&client_id=%s&logout_redirect_uri=%s",
+                oauthLogoutUri, clientId, logoutRedirectUri);
     }
 
     // 카카오 accessToken 발급

--- a/src/main/java/org/example/pongguel/user/service/KakaoService.java
+++ b/src/main/java/org/example/pongguel/user/service/KakaoService.java
@@ -126,6 +126,7 @@ public class KakaoService {
                .orElseGet(()->{
                    // 회원정보가 없다면 회원가입 진행
                    User newUser = User.builder()
+                           .kakaoId(kakaoUserInfo.id())
                            .accountEmail(kakaoUserInfo.email())
                            .nickname(kakaoUserInfo.nickname())
                            .profileImage(kakaoUserInfo.thumbnail_image_url())


### PR DESCRIPTION
## Issue
- #9 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
ex) feat/user_loggout -> dev

## 변경 사항
- 카카오 로그아웃과 퐁글퐁글 서비스 로그아웃 기능 구현
- 퐁글퐁글 메인 페이지 임시 설정

## 테스트 결과

### Request
```java
HTTP : GET
URL: /api/kakao/logout
```

### Response : 성공시

```
카카오 로그아웃 페이지로 리다이렉트됩니다.

```
<img width="572" alt="카카오 로그아웃" src="https://github.com/user-attachments/assets/11d4ed12-b841-4370-97c1-03d7ee34e771" width="90%" height="100%">