### PR TITLE
[feat] 책 저장하기 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // org.json
+    implementation 'org.json:json:20240303'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework:spring-webflux'
     testImplementation 'org.springframework.security:spring-security-test'
-    testImplementation 'org.springframework.graphql:spring-graphql-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-graphql'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'

--- a/src/main/java/org/example/pongguel/book/controller/BookController.java
+++ b/src/main/java/org/example/pongguel/book/controller/BookController.java
@@ -2,15 +2,17 @@ package org.example.pongguel.book.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.example.pongguel.book.dto.SaveSelectedBookResponse;
 import org.example.pongguel.book.dto.SearchBookList;
 import org.example.pongguel.book.service.BookService;
+import org.example.pongguel.exception.ErrorCode;
+import org.example.pongguel.exception.UnauthorizedException;
+import org.example.pongguel.jwt.JwtUtil;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name="Book",description = "책 서비스 관련된 Api입니다.")
 public class BookController {
     private final BookService bookService;
+    private final JwtUtil jwtUtil;
 
     @GetMapping("/search")
     @Operation(summary = "책 검색", description = "검색어를 입력해 네이버 책 조회 서비스를 활용합니다.")
@@ -27,6 +30,18 @@ public class BookController {
                                                                        @RequestParam(defaultValue = "sim") String sort) {
         SearchBookList response = bookService.searchBookList(query, display, start, sort);
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PostMapping("/save")
+    @Operation(summary = "사용자가 검색한 책을 저장합니다.", description = "책의 ISBN을 활용해 상세 정보를 조회하고 저장합니다.")
+    public ResponseEntity<SaveSelectedBookResponse> saveSelectedBook(HttpServletRequest request,
+                                                                     @RequestParam Long isbn){
+        String token = jwtUtil.extractTokenFromRequest(request);
+        if (token == null) {
+            throw new UnauthorizedException(ErrorCode.JWT_INVALID_TOKEN);
+        }
+        SaveSelectedBookResponse saveSelectedBook = bookService.SaveSelectedBook(token,isbn);
+        return ResponseEntity.status(HttpStatus.CREATED).body(saveSelectedBook);
     }
 
 }

--- a/src/main/java/org/example/pongguel/book/dto/SaveSelectedBookResponse.java
+++ b/src/main/java/org/example/pongguel/book/dto/SaveSelectedBookResponse.java
@@ -1,0 +1,10 @@
+package org.example.pongguel.book.dto;
+
+public record SaveSelectedBookResponse(String message,
+                                       String bookTitle,
+                                       String description,
+                                       String imageUrl,
+                                       String author,
+                                       String publisher,
+                                       Long isbn) {
+}

--- a/src/main/java/org/example/pongguel/book/dto/SelectedBook.java
+++ b/src/main/java/org/example/pongguel/book/dto/SelectedBook.java
@@ -1,0 +1,9 @@
+package org.example.pongguel.book.dto;
+
+public record SelectedBook(String bookTitle,
+                           String description,
+                           String imageUrl,
+                           String author,
+                           String publisher,
+                           Long isbn) {
+}

--- a/src/main/java/org/example/pongguel/book/repository/BookRepository.java
+++ b/src/main/java/org/example/pongguel/book/repository/BookRepository.java
@@ -3,5 +3,9 @@ package org.example.pongguel.book.repository;
 import org.example.pongguel.book.domain.Book;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BookRepository extends JpaRepository<Book, Long> {
+    //ISBN으로 책 정보 찾기
+    Optional<Book> findByIsbn(Long isbn);
 }

--- a/src/main/java/org/example/pongguel/config/SecurityConfig.java
+++ b/src/main/java/org/example/pongguel/config/SecurityConfig.java
@@ -2,7 +2,6 @@ package org.example.pongguel.config;
 
 import lombok.RequiredArgsConstructor;
 import org.example.pongguel.jwt.JwtAuthenticationFilter;
-import org.example.pongguel.jwt.JwtTokenProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -19,7 +18,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final JwtTokenProvider jwtTokenProvider;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean

--- a/src/main/java/org/example/pongguel/exception/ErrorCode.java
+++ b/src/main/java/org/example/pongguel/exception/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
     JWT_REFRESH_BAD_REQUEST(HttpStatus.BAD_REQUEST,"리프레시 토큰이 일치하지 않습니다."),
     //401
     JWT_REFRESH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"리프레시 토큰 재발급 권한이 없습니다."),
+    JWT_INVALID_TOKEN(HttpStatus.UNAUTHORIZED,"권한이 없는 토큰입니다."),
 
     // 책 조회
     //400

--- a/src/main/java/org/example/pongguel/jwt/controller/JwtController.java
+++ b/src/main/java/org/example/pongguel/jwt/controller/JwtController.java
@@ -1,11 +1,11 @@
-package org.example.pongguel.user.controller;
+package org.example.pongguel.jwt.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.example.pongguel.user.dto.JwtTokenDto;
-import org.example.pongguel.user.dto.TokenRefreshRequest;
-import org.example.pongguel.user.service.JwtService;
+import org.example.pongguel.jwt.dto.JwtTokenDto;
+import org.example.pongguel.jwt.dto.TokenRefreshRequest;
+import org.example.pongguel.jwt.service.JwtService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/org/example/pongguel/jwt/domain/CustomUserDetails.java
+++ b/src/main/java/org/example/pongguel/jwt/domain/CustomUserDetails.java
@@ -1,5 +1,6 @@
-package org.example.pongguel.user.domain;
+package org.example.pongguel.jwt.domain;
 
+import org.example.pongguel.user.domain.User;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -7,10 +8,10 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.Collections;
 
-public class CustomUserDeatils implements UserDetails {
+public class CustomUserDetails implements UserDetails {
     private final User user;
 
-    public CustomUserDeatils(User user) {
+    public CustomUserDetails(User user) {
         this.user = user;
     }
 

--- a/src/main/java/org/example/pongguel/jwt/dto/JwtTokenDto.java
+++ b/src/main/java/org/example/pongguel/jwt/dto/JwtTokenDto.java
@@ -1,4 +1,4 @@
-package org.example.pongguel.user.dto;
+package org.example.pongguel.jwt.dto;
 
 public record JwtTokenDto(String accessToken,
                           String refreshToken) {

--- a/src/main/java/org/example/pongguel/jwt/dto/TokenRefreshRequest.java
+++ b/src/main/java/org/example/pongguel/jwt/dto/TokenRefreshRequest.java
@@ -1,4 +1,4 @@
-package org.example.pongguel.user.dto;
+package org.example.pongguel.jwt.dto;
 
 public record TokenRefreshRequest(String refreshToken) {
 }

--- a/src/main/java/org/example/pongguel/jwt/service/JwtService.java
+++ b/src/main/java/org/example/pongguel/jwt/service/JwtService.java
@@ -1,11 +1,11 @@
-package org.example.pongguel.user.service;
+package org.example.pongguel.jwt.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.pongguel.jwt.JwtTokenProvider;
 import org.example.pongguel.exception.BadRequestException;
 import org.example.pongguel.exception.ErrorCode;
-import org.example.pongguel.user.dto.JwtTokenDto;
+import org.example.pongguel.jwt.JwtTokenProvider;
+import org.example.pongguel.jwt.dto.JwtTokenDto;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/org/example/pongguel/jwt/service/UserDetailService.java
+++ b/src/main/java/org/example/pongguel/jwt/service/UserDetailService.java
@@ -1,10 +1,8 @@
-package org.example.pongguel.user.service;
+package org.example.pongguel.jwt.service;
 
 import lombok.RequiredArgsConstructor;
-import org.example.pongguel.exception.BadRequestException;
-import org.example.pongguel.exception.ErrorCode;
 import org.example.pongguel.user.domain.User;
-import org.example.pongguel.user.domain.CustomUserDeatils;
+import org.example.pongguel.jwt.domain.CustomUserDetails;
 import org.example.pongguel.user.repository.UserRepository;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -16,9 +14,9 @@ public class UserDetailService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public CustomUserDeatils loadUserByUsername(String email) throws UsernameNotFoundException {
+    public CustomUserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         User user = userRepository.findByAccountEmail(email)
-                .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND));
-        return new CustomUserDeatils(user);
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+        return new CustomUserDetails(user);
     }
 }

--- a/src/main/java/org/example/pongguel/redis/RedisController.java
+++ b/src/main/java/org/example/pongguel/redis/RedisController.java
@@ -2,7 +2,7 @@ package org.example.pongguel.redis;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.example.pongguel.user.service.JwtService;
+import org.example.pongguel.jwt.service.JwtService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/org/example/pongguel/user/controller/KakaoController.java
+++ b/src/main/java/org/example/pongguel/user/controller/KakaoController.java
@@ -2,12 +2,9 @@ package org.example.pongguel.user.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.example.pongguel.user.dto.KakaoUserInfo;
 import org.example.pongguel.user.dto.LoginResponse;
 import org.example.pongguel.user.dto.LoginResult;
-import org.example.pongguel.user.dto.UserInfoResponse;
 import org.example.pongguel.user.service.KakaoService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/org/example/pongguel/user/dto/LoginResponse.java
+++ b/src/main/java/org/example/pongguel/user/dto/LoginResponse.java
@@ -1,5 +1,7 @@
 package org.example.pongguel.user.dto;
 
+import org.example.pongguel.jwt.dto.JwtTokenDto;
+
 public record LoginResponse(String message,
                             UserInfoResponse userInfoResponse,
                             JwtTokenDto jwtTokenDto) {

--- a/src/main/java/org/example/pongguel/user/service/KakaoService.java
+++ b/src/main/java/org/example/pongguel/user/service/KakaoService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.pongguel.jwt.JwtTokenProvider;
 import org.example.pongguel.exception.*;
+import org.example.pongguel.jwt.dto.JwtTokenDto;
 import org.example.pongguel.user.domain.Role;
 import org.example.pongguel.user.domain.User;
 import org.example.pongguel.user.dto.*;


### PR DESCRIPTION
## Issue
- #13 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
ex) feat/book_save -> dev

## 변경 사항
- `GraphQL` 의존성 삭제
- 사용자가 선택한 책의 `ISBN`을 바탕으로 책을 상세조회하고 저장합니다.
- 이미 저장된 책 정보는 다시 저장되지 않습니다.

## 테스트 결과

### Request

```java
HTTP : POST
URL: /api/books/save
```

- Request Header

```
Authorization: “Bearer XXXXXXXXX”
```

- Request Param

```
isbn: “책의 Isbn”
```

### Response : 성공시

`201 CREATED`

```
{
  "message": "책을 성공적으로 저장했습니다.",
  "bookTitle": "책 제목",
  "description": "책 설명",
  "imageUrl": "책 이미지 경로",
  "author": "작가",
  "publisher": "출판사",
  "isbn": "책의 isbn"
}

```

### Response : 실패시

`400 Bad Request`

- requestBody의 요청 형식이 올바르지 않은 경우
- 유효하지 않은 토큰일 경우

```
{
   "status": 400,
  "message": "책 정보 추가 요청 본문의 형식이 올바르지 않습니다."
}
```
```
{
   "status": 400,
  "message": "유효하지 않은 리프레시 토큰입니다."
}
```

`401 UNAUTHORIZED`

```
{
   "status": 401,
  "message": "인증정보가 만료됐습니다. 다시 로그인해주세요."
}
```

`404 NOT FOUND`

```
{
   "status": 404,
  "message": "존재하지 않는 사용자입니다."
}
```
