### PR TITLE
[feat] 노트 생성 기능 구현

### DIFF
--- a/src/main/java/org/example/pongguel/note/controller/NoteController.java
+++ b/src/main/java/org/example/pongguel/note/controller/NoteController.java
@@ -1,0 +1,37 @@
+package org.example.pongguel.note.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.example.pongguel.exception.ErrorCode;
+import org.example.pongguel.exception.UnauthorizedException;
+import org.example.pongguel.jwt.JwtUtil;
+import org.example.pongguel.note.dto.NoteCreateRequest;
+import org.example.pongguel.note.dto.NoteCreateResponse;
+import org.example.pongguel.note.service.NoteService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notes")
+@Tag(name="Note", description = "노트 서비스와 관련된 Api입니다.")
+public class NoteController {
+    private final NoteService noteService;
+    private final JwtUtil jwtUtil;
+
+    @PostMapping("/{bookId}/write")
+    @Operation(summary = "노트를 저장합니다.", description = "사용자가 책에 관하여 작성한 노트를 저장합니다.")
+    public ResponseEntity<NoteCreateResponse> createNote(HttpServletRequest request,
+                                                         @PathVariable Long bookId,
+                                                         @RequestBody NoteCreateRequest noteCreateRequest) {
+        String token = jwtUtil.extractTokenFromRequest(request);
+        if (token == null) {
+            throw new UnauthorizedException(ErrorCode.JWT_INVALID_TOKEN);
+        }
+        NoteCreateResponse noteCreateResponse = noteService.createNote(token,bookId,noteCreateRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(noteCreateResponse);
+    }
+}

--- a/src/main/java/org/example/pongguel/note/domain/Note.java
+++ b/src/main/java/org/example/pongguel/note/domain/Note.java
@@ -1,0 +1,50 @@
+package org.example.pongguel.note.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+import org.example.pongguel.book.domain.Book;
+import org.example.pongguel.user.domain.User;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "notes")
+public class Note {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "note_id")
+    private Long noteId;
+
+    @Column(nullable = false)
+    @Size(min = 1, max = 50)
+    private String noteTitle;
+
+    @Column(nullable = false)
+    @Size(min = 1, max = 200)
+    private String contents;
+
+    @CreationTimestamp
+    private LocalDate noteCreatedAt;
+
+    @Column(name = "is_bookmarked",nullable = false)
+    private boolean isBookmarked=false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id")
+    private Book book;
+
+    // 즐겨찾기 기능
+    public void toggleBookmark(){
+        this.isBookmarked=!this.isBookmarked;
+    }
+}

--- a/src/main/java/org/example/pongguel/note/dto/NoteCreateRequest.java
+++ b/src/main/java/org/example/pongguel/note/dto/NoteCreateRequest.java
@@ -1,0 +1,5 @@
+package org.example.pongguel.note.dto;
+
+public record NoteCreateRequest(String noteTitle,
+                                String contents) {
+}

--- a/src/main/java/org/example/pongguel/note/dto/NoteCreateResponse.java
+++ b/src/main/java/org/example/pongguel/note/dto/NoteCreateResponse.java
@@ -1,0 +1,15 @@
+package org.example.pongguel.note.dto;
+
+import java.time.LocalDate;
+
+public record NoteCreateResponse(String message,
+                                 String nickname,
+                                 Long bookId,
+                                 String bookTitle,
+                                 String imageUrl,
+                                 Long noteId,
+                                 String noteTitle,
+                                 String contents,
+                                 LocalDate noteCreatedAt,
+                                 boolean isBookmarked) {
+}

--- a/src/main/java/org/example/pongguel/note/repository/NoteRepository.java
+++ b/src/main/java/org/example/pongguel/note/repository/NoteRepository.java
@@ -1,0 +1,7 @@
+package org.example.pongguel.note.repository;
+
+import org.example.pongguel.note.domain.Note;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoteRepository extends JpaRepository<Note, Long> {
+}

--- a/src/main/java/org/example/pongguel/note/service/NoteService.java
+++ b/src/main/java/org/example/pongguel/note/service/NoteService.java
@@ -40,7 +40,9 @@ public class NoteService {
                 .user(user)
                 .book(book)
                 .build();
-        // 4. NoteCreateResponse 생성 및 반환
+        // 4. 노트 저장
+        noteRepository.save(note);
+        // 5. NoteCreateResponse 생성 및 반환
         return createNoteCreateResponse(note);
     }
     // 노트 상세 조회

--- a/src/main/java/org/example/pongguel/note/service/NoteService.java
+++ b/src/main/java/org/example/pongguel/note/service/NoteService.java
@@ -1,0 +1,68 @@
+package org.example.pongguel.note.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.pongguel.book.domain.Book;
+import org.example.pongguel.book.repository.BookRepository;
+import org.example.pongguel.exception.ErrorCode;
+import org.example.pongguel.exception.NotFoundException;
+import org.example.pongguel.note.domain.Note;
+import org.example.pongguel.note.dto.NoteCreateRequest;
+import org.example.pongguel.note.dto.NoteCreateResponse;
+import org.example.pongguel.note.repository.NoteRepository;
+import org.example.pongguel.user.domain.User;
+import org.example.pongguel.user.service.ValidateUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NoteService {
+    private final NoteRepository noteRepository;
+    private final BookRepository bookRepository;
+    private final ValidateUser validateUser;
+
+    // 노트 생성
+    public NoteCreateResponse createNote(String token, Long bookId, NoteCreateRequest noteCreateRequest) {
+        // 1. 토큰 유효성 검사 및 사용자 권한 인증
+        User user = validateUser.getUserFromToken(token);
+        // 2. bookId로 책 정보 및 사용자의 저장 여부 확인
+        Book book = bookRepository.findByBookIdAndUser_UserId(bookId,user.getUserId())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.BOOK_SAVED_NOT_FOUND));
+        // 3. Note 생성
+        Note note = Note.builder()
+                .noteTitle(noteCreateRequest.noteTitle())
+                .contents(noteCreateRequest.contents())
+                .noteCreatedAt(LocalDate.now())
+                .isBookmarked(false)
+                .user(user)
+                .book(book)
+                .build();
+        // 4. NoteCreateResponse 생성 및 반환
+        return createNoteCreateResponse(note);
+    }
+    // 노트 상세 조회
+    // 노트 수정
+    // 노트 삭제
+    // 노트 전체 조회
+    // 노트 즐겨찾기
+    // 즐겨찾기한 노트 조회
+
+    // NoteCreateResponse 생성 및 반환
+    private NoteCreateResponse createNoteCreateResponse(Note note) {
+        return new NoteCreateResponse(
+                "노트가 성공적으로 저장됐습니다.",
+                note.getUser().getNickname(),
+                note.getBook().getBookId(),
+                note.getBook().getBookTitle(),
+                note.getBook().getImageUrl(),
+                note.getNoteId(),
+                note.getNoteTitle(),
+                note.getContents(),
+                note.getNoteCreatedAt(),
+                note.isBookmarked()
+        );
+    }
+}


### PR DESCRIPTION
## Issue
- #21 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
ex) feat/note_create -> dev

## 변경 사항
- 사용자는 저장한 책에 대해서 노트를 작성할 수 있습니다.
- 노트는 제한없이 생성 가능합니다.

## 테스트 결과

### Request
```java
HTTP : POST
URL: /api/notes/{bookId}/write
```
- Header
```
Authorization: “Bearer XXXXXXXXX”
```
- PathValue
```
Long: bookId
```
-Request Body
```
{
  "noteTitle": "노트 제목",
  "contents": "노트 내용"
}
```

### Response : 성공시

`201 CREATED`
```
{
    "message": "노트가 성공적으로 저장됐습니다.",
    "nickname": "닉네임",
    "bookId": "책_일련번호",
    "bookTitle": "책 제목",
    "imageUrl": "책 url",
    "noteId": "노트_일련번호",
    "noteTitle": "노트 제목",
    "contents": "노트 내용",
    "noteCreatedAt": "생성일",
    "isBookmarked": "북마크 여부, default=false"
}
```

### Response : 실패시

`400 Bad Request`

```
{
   "status": 400,
  "message": "요청 형식이 올바르지 않습니다." or "유효하지 않은 토큰입니다."
}
```
`403 FORBIDDEN`
```

{
   "status": 403,
  "message": "서비스 접근 권한이 없습니다."
}
```
`404 NOT FOUND`
```
{
   "status": 404,
  "message": "존재하지 않는 사용자입니다."
}
```

