### PR TITLE
[feat] 마이페이지 및 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/org/example/pongguel/book/repository/BookRepository.java
+++ b/src/main/java/org/example/pongguel/book/repository/BookRepository.java
@@ -19,4 +19,6 @@ public interface BookRepository extends JpaRepository<Book, Long> {
    // 사용자가 좋아요한 책 정보 찾기
     @Query("SELECT b FROM Book b WHERE b.user.userId = :userId AND b.isLiked=true")
     List<Book> findByUser_UserIdAndIsLiked(@Param("userId") UUID userId);
+    // 사용자가 저장한 책 삭제
+    void deleteAllBooksByUser_UserId(UUID userId);
 }

--- a/src/main/java/org/example/pongguel/exception/ErrorCode.java
+++ b/src/main/java/org/example/pongguel/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     KAKAO_ACCESS_TOKEN_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"OAuth 서버 일시적 오류가 생겼습니다."),
     KAKAO_USER_INFO_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"카카오서버 내부의 일시적 오류가 생겼습니다."),
     PROCESS_USER_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"데이터베이스 오류가 생겼습니다."),
+    KAKAO_LEAVE_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"탈퇴 중 서비스 오류가 발생했습니다"),
 
     // jwt 발급
     //400

--- a/src/main/java/org/example/pongguel/note/repository/NoteRepository.java
+++ b/src/main/java/org/example/pongguel/note/repository/NoteRepository.java
@@ -23,5 +23,7 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
     List<Note> findByBook_BookId(Long bookId);
     // 책 관련 모든 노트 삭제
     void deleteByBook_BookId(Long bookId);
+    // 사용자 관련 모든 노트 삭제
+    void deleteAllNotesByUser_UserId(UUID userId);
 }
 

--- a/src/main/java/org/example/pongguel/user/controller/KakaoSignOutController.java
+++ b/src/main/java/org/example/pongguel/user/controller/KakaoSignOutController.java
@@ -24,7 +24,6 @@ public class KakaoSignOutController {
     private final KakaoSignOutService kakaoSignOutService;
     private final JwtUtil jwtUtil;
 
-    // 카카오 로그아웃 페이지로 리다이렉트
     @GetMapping("/sign-out")
     @Operation(summary = "카카오 로그아웃 기능입니다.", description = "서비스 로그아웃뿐만 아니라 카카오톡 액세스토큰도 만료합니다.")
     public ResponseEntity<String> logout(HttpServletRequest request) {

--- a/src/main/java/org/example/pongguel/user/controller/UserDetailController.java
+++ b/src/main/java/org/example/pongguel/user/controller/UserDetailController.java
@@ -1,0 +1,49 @@
+package org.example.pongguel.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.example.pongguel.exception.ErrorCode;
+import org.example.pongguel.exception.UnauthorizedException;
+import org.example.pongguel.jwt.JwtUtil;
+import org.example.pongguel.user.dto.PongUserInfo;
+import org.example.pongguel.user.dto.UnlinkedUserDto;
+import org.example.pongguel.user.service.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+@Tag(name="MY_PAGE",description = "사용자 마이페이지에 관련된 Api입니다.")
+public class UserDetailController {
+    private final UserService userService;
+    private final JwtUtil jwtUtil;
+
+    @GetMapping("/my-page")
+    @Operation(summary = "회원 마이페이지", description = "회원 마이페이지 서비스입니다.")
+    public ResponseEntity<PongUserInfo> myPage(HttpServletRequest request) {
+        String token = jwtUtil.extractTokenFromRequest(request);
+        if (token == null) {
+            throw new UnauthorizedException(ErrorCode.JWT_INVALID_TOKEN);
+        }
+        PongUserInfo pongUserInfo = userService.getUserInfo(token);
+        return ResponseEntity.status(HttpStatus.OK).body(pongUserInfo);
+    }
+
+    @GetMapping("/leave")
+    @Operation(summary = "회원 탈퇴", description = "서비스뿐만 아니라 카카오 연결도 끊기게 됩니다.")
+    public ResponseEntity<UnlinkedUserDto> leave(HttpServletRequest request) {
+        String token = jwtUtil.extractTokenFromRequest(request);
+        if (token == null) {
+            throw new UnauthorizedException(ErrorCode.JWT_INVALID_TOKEN);
+        }
+        UnlinkedUserDto unlinkedUserDto = userService.leave(token);
+        return ResponseEntity.status(HttpStatus.OK).body(unlinkedUserDto);
+    }
+}

--- a/src/main/java/org/example/pongguel/user/controller/UserDetailController.java
+++ b/src/main/java/org/example/pongguel/user/controller/UserDetailController.java
@@ -14,7 +14,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController

--- a/src/main/java/org/example/pongguel/user/dto/PongUserInfo.java
+++ b/src/main/java/org/example/pongguel/user/dto/PongUserInfo.java
@@ -1,0 +1,8 @@
+package org.example.pongguel.user.dto;
+
+public record PongUserInfo(String accountEmail,
+                           String nickname,
+                           String profileImage,
+                           Long bookCount,
+                           Long noteCount) {
+}

--- a/src/main/java/org/example/pongguel/user/dto/UnlinkedUserDto.java
+++ b/src/main/java/org/example/pongguel/user/dto/UnlinkedUserDto.java
@@ -1,0 +1,5 @@
+package org.example.pongguel.user.dto;
+
+public record UnlinkedUserDto(String message,
+                              Long kakaoId) {
+}

--- a/src/main/java/org/example/pongguel/user/service/UserService.java
+++ b/src/main/java/org/example/pongguel/user/service/UserService.java
@@ -1,0 +1,104 @@
+package org.example.pongguel.user.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.pongguel.book.domain.Book;
+import org.example.pongguel.book.repository.BookRepository;
+import org.example.pongguel.exception.BadRequestException;
+import org.example.pongguel.exception.ErrorCode;
+import org.example.pongguel.exception.InternalServerException;
+import org.example.pongguel.note.domain.Note;
+import org.example.pongguel.note.repository.NoteRepository;
+import org.example.pongguel.user.domain.KakaoToken;
+import org.example.pongguel.user.domain.User;
+import org.example.pongguel.user.dto.PongUserInfo;
+import org.example.pongguel.user.dto.UnlinkedUserDto;
+import org.example.pongguel.user.repository.KakaoTokenRepository;
+import org.example.pongguel.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class UserService {
+    @Value("${kakao.user_base_url}")
+    private String userBaseUrl;
+    private final UserRepository userRepository;
+    private final KakaoTokenRepository kakaoTokenRepository;
+    private final BookRepository bookRepository;
+    private final NoteRepository noteRepository;
+    private final ValidateUser validateUser;
+    private final WebClient webClient;
+
+    // 사용자 정보 조회 (마이페이지)
+    public PongUserInfo getUserInfo(String token){
+        // 1. 토큰 유효성 검사 및 사용자 정보 가져오기
+        User user = validateUser.getUserFromToken(token);
+        // 2. 사용자가 저장한 책의 수
+        List<Book> savedBooks = bookRepository.findByUser_UserId(user.getUserId());
+        long savedBooksCount = savedBooks.size();
+        // 3. 사용자가 작성한 노트 수
+        List<Note> notes = noteRepository.findAllByUser_userIdAndIsDeletedOrderByNoteCreatedAtDesc(user.getUserId(), false);
+        long notesCount = notes.size();
+
+        // 4. PongUserInfo 생성
+        return new PongUserInfo(
+                user.getAccountEmail(),
+                user.getNickname(),
+                user.getProfileImage(),
+                savedBooksCount,
+                notesCount
+        );
+    }
+
+    // 유저 연결 끊기
+    public UnlinkedUserDto leave(String token){
+        try {
+            // 1. 토큰 유효성 검사 및 사용자 권한 인증
+            User user = validateUser.getUserFromToken(token);
+            // 2. 카카오 액세스 토큰 찾기
+            KakaoToken kakaoToken = kakaoTokenRepository.findByUser_userId(user.getUserId())
+                    .orElseThrow(()->new BadRequestException(ErrorCode.KAKAO_TOKEN_NOT_FOUND));
+            // 3. 카카오 계정 연결 끊기
+            unlink(kakaoToken.getKakaoAccessToken());
+            // 4. 사용자의 모든 노트 삭제
+            noteRepository.deleteAllNotesByUser_UserId(user.getUserId());
+            // 5. 사용자의 모든 책 삭제
+            bookRepository.deleteAllBooksByUser_UserId(user.getUserId());
+            //6. 사용자 카카오 토큰 삭제
+            kakaoTokenRepository.delete(kakaoToken);
+            //7. 사용자 서버 삭제
+            userRepository.delete(user);
+            return new UnlinkedUserDto("회원 탈퇴가 성공적으로 이뤄졌습니다.", user.getKakaoId());
+        } catch (Exception e) {
+            log.error("회원 탈퇴 처리 중 오류 발생", e);
+            throw new InternalServerException(ErrorCode.KAKAO_LEAVE_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // 카카오 연결 끊기
+    private void unlink(String accessToken){
+        webClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .host(userBaseUrl)
+                        .path("/user/unlink")
+                        .build())
+                .header("Authorization","Bearer " + accessToken)
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .map(jsonNode -> jsonNode.path("id").asLong())
+                .onErrorMap(WebClientResponseException.class, e -> {
+                    log.error("카카오 연결 끊기 실패. 상태 코드: {}, 응답: {}", e.getRawStatusCode(), e.getResponseBodyAsString());
+                    return new BadRequestException(ErrorCode.KAKAO_ACCESS_TOKEN_BAD_REQUEST);
+                })
+                .block();
+    }
+}


### PR DESCRIPTION
## Issue
- #36 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
ex) feat/user_delete -> dev

## 변경 사항

## 테스트 결과

<details>
  <summary><strong>마이페이지</strong></summary>
  <div markdown="1">

- Request Header

```
Authorization: “Bearer XXXXXXXXX”
```


### Request
```java
HTTP : GET
URL: /api/users/my-page
```

### Response : 성공시

`200 OK`

```
{
  "accountEmail": "이메일",
  "nickname": "닉네임",
  "profileImage": "이미지url",
  "bookCount": "저장한 책 수",
  "noteCount": "작성한 노트 수"
}
```

</details>

<details>
  <summary><strong>회원 탈퇴</strong></summary>
  <div markdown="1">

- Request Header

```
Authorization: “Bearer XXXXXXXXX”
```


### Request
```java
HTTP : POST
URL: /api/users/leave

### Response : 성공시

`200 OK`

```
{
  "message": "회원 탈퇴가 성공적으로 이뤄졌습니다.",
  "kakaoId": "회원의 카카오ID"
}
```

</details>